### PR TITLE
docs: update setup readme

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+ALCHEMY_ID=

--- a/README.md
+++ b/README.md
@@ -29,9 +29,22 @@ The IERC721Soulbound interface extends IERC721 with a few new methods:
 `canReclaim(address claimant, uint256 tokenId)` Check if an address can reclaim a token.
 
 ## test
+Set up .env file by copying the example and adding your alchemy key:
+```
+$ cp .env.example .env
+```
 
+Install dependencies:
+```
 yarn
+```
 
+Compile:
+```
 yarn compile
+```
 
+Test:
+```
 yarn test
+```


### PR DESCRIPTION
Since the witches' address is hardcoded on Spellbound, it looks like you fork mainnet for local testing which requires having an `ALCHEMY_ID` key set up. Ran into this issue when I first ran the tests. This PR just updates the README to point that out.